### PR TITLE
Fix 401 Unauthorized on OVHcloud calls

### DIFF
--- a/llm_benchmark_suite.py
+++ b/llm_benchmark_suite.py
@@ -202,10 +202,11 @@ class _OvhLlm(_Llm):
     """See https://llama-3-70b-instruct.endpoints.kepler.ai.cloud.ovh.net/doc"""
 
     def __init__(self, model: str, display_model: Optional[str] = None):
+        model_name = model.split("/")[1]
         super().__init__(
-            "",
+            model,
             "endpoints.ai.cloud.ovh.net/" + display_model,
-            base_url=f"https://{model}.endpoints.kepler.ai.cloud.ovh.net/api/openai_compat/v1",
+            base_url=f"https://{model_name}.endpoints.kepler.ai.cloud.ovh.net/api/openai_compat/v1",
         )
 
 
@@ -309,7 +310,7 @@ def _text_models():
         _OctoLlm("meta-llama-3-70b-instruct", LLAMA_3_70B_CHAT),
         _PerplexityLlm("llama-3-70b-instruct", LLAMA_3_70B_CHAT),
         _TogetherLlm("meta-llama/Llama-3-70b-chat-hf", LLAMA_3_70B_CHAT),
-        _OvhLlm("llama-3-70b-instruct", LLAMA_3_70B_CHAT),
+        _OvhLlm("ovhcloud/llama-3-70b-instruct", LLAMA_3_70B_CHAT),
         # Function calling with Llama 3 70b
         _FireworksLlm("accounts/fireworks/models/firefunction-v2", "firefunction-v2"),
         # Llama 3 8b
@@ -322,7 +323,7 @@ def _text_models():
         _OctoLlm("meta-llama-3-8b-instruct", LLAMA_3_8B_CHAT),
         _PerplexityLlm("llama-3-8b-instruct", LLAMA_3_8B_CHAT),
         _TogetherLlm("meta-llama/Llama-3-8b-chat-hf", LLAMA_3_8B_CHAT),
-        _OvhLlm("llama-3-8b-instruct", LLAMA_3_8B_CHAT),
+        _OvhLlm("ovhcloud/llama-3-8b-instruct", LLAMA_3_8B_CHAT),
         # Phi-2
         _CloudflareLlm("@cf/microsoft/phi-2", PHI_2),
         _TogetherLlm("microsoft/phi-2", PHI_2),

--- a/llm_request.py
+++ b/llm_request.py
@@ -236,6 +236,15 @@ async def openai_chat(ctx: ApiContext, path: str = "/chat/completions") -> ApiRe
     return await post(ctx, url, headers, data, openai_chunk_gen)
 
 
+async def ovhllm_chat(ctx: ApiContext, path: str = "/chat/completions") -> ApiResult:
+    url, headers = make_openai_url_and_headers(ctx, path)
+    data = make_openai_chat_body(ctx, messages=make_openai_messages(ctx))
+    # Clean up the headers and data for OVH.
+    headers.pop("authorization")
+    data.pop("model")
+    return await post(ctx, url, headers, data, openai_chunk_gen)
+
+
 async def openai_embed(ctx: ApiContext) -> ApiResult:
     url, headers = make_openai_url_and_headers(ctx, "/embeddings")
     data = {"model": ctx.model, "input": ctx.prompt}
@@ -562,6 +571,8 @@ def make_context(
         case "fake":
             provider = "test"
             func = fake_chat
+        case "ovhcloud":
+            func = ovhllm_chat
         case _ if args.base_url or model.startswith("gpt-") or model.startswith(
             "ft:gpt-"
         ):


### PR DESCRIPTION
Since few days OVHcloud AI Endpoints are rejecting anonymous calls with an Authorization header. Therefore if we remove the header it won't return 401 errors anymore.