### PR TITLE
Allow serial requests and control of connection reuse

### DIFF
--- a/llm_request.py
+++ b/llm_request.py
@@ -32,6 +32,10 @@ class InputFile:
             data = f.read()
         return cls(mime_type, data)
 
+    @classmethod
+    def from_bytes(cls, mime_type: str, data: bytes):
+        return cls(mime_type, data)
+
     mime_type: str
     data: bytes
 
@@ -100,8 +104,10 @@ class ApiContext:
                         if not first_token_time:
                             first_token_time = time.time()
                             self.metrics.ttft = first_token_time - start_time
-                        if on_token:
+                        if on_token and chunk:
                             on_token(self, chunk)
+                    if on_token:
+                        on_token(self, "")
             else:
                 self.metrics.error = f"{response.status} {response.reason}"
         except TimeoutError:


### PR DESCRIPTION
- no-reuse-connections disables connection reuse
- parallel-requests controls how many parallel requests (by default 1)
- add tracing for request serialization
- print TTFT and total time with -v
- `chosen` now only controls which request is printed
- move EOF control into on_token