### PR TITLE
use updated baseten url

### DIFF
--- a/llm_benchmark_suite.py
+++ b/llm_benchmark_suite.py
@@ -373,7 +373,7 @@ def _audio_models():
         _Llm(
             "fixie-ai/ultravox-v0.2",
             "baseten.co/ultravox-v0.2",
-            base_url="https://bridge.baseten.co/5wovovzq/direct/v1",
+            base_url="https://bridge.baseten.co/5wovovzq/v1/direct",
             api_key=os.getenv("BASETEN_API_KEY"),
         ),
     ]


### PR DESCRIPTION
Howdy Fixie! 

We made some route changes to the URL for the OAI Bridge service to align it with API best practices. Hoping to propagate those changes here! 