### PR TITLE
Remove Anyscale models

### DIFF
--- a/llm_benchmark_suite.py
+++ b/llm_benchmark_suite.py
@@ -121,18 +121,6 @@ class _Llm:
         return await llm_benchmark.run(full_argv)
 
 
-class _AnyscaleLlm(_Llm):
-    """See https://docs.endpoints.anyscale.com/text-generation/query-a-model"""
-
-    def __init__(self, model: str, display_model: Optional[str] = None):
-        super().__init__(
-            model,
-            "anyscale.com/" + (display_model or model),
-            api_key=os.getenv("ANYSCALE_API_KEY"),
-            base_url="https://api.endpoints.anyscale.com/v1",
-        )
-
-
 class _CloudflareLlm(_Llm):
     """See https://developers.cloudflare.com/workers-ai/models/"""
 
@@ -332,7 +320,6 @@ def _text_models():
         #    api_key=os.getenv("AZURE_EASTUS2_MISTRAL_API_KEY"),
         #    base_url="https://fixie-mistral-serverless.eastus2.inference.ai.azure.com/v1",
         # ),
-        _AnyscaleLlm("mistralai/Mixtral-8x22B-Instruct-v0.1", MIXTRAL_8X22B_INSTRUCT),
         _DeepInfraLlm("mistralai/Mixtral-8x22B-Instruct-v0.1", MIXTRAL_8X22B_INSTRUCT),
         _FireworksLlm(
             "accounts/fireworks/models/mixtral-8x22b-instruct",
@@ -347,7 +334,6 @@ def _text_models():
         _OctoLlm("mixtral-8x22b-instruct", MIXTRAL_8X22B_INSTRUCT),
         _TogetherLlm("mistralai/Mixtral-8x22B-Instruct-v0.1", MIXTRAL_8X22B_INSTRUCT),
         # Mistral 8x7b
-        _AnyscaleLlm("mistralai/Mixtral-8x7B-Instruct-v0.1", MIXTRAL_8X7B_INSTRUCT),
         _DatabricksLlm("databricks-mixtral-8x7b-instruct", MIXTRAL_8X7B_INSTRUCT),
         _DeepInfraLlm("mistralai/Mixtral-8x7B-Instruct-v0.1", MIXTRAL_8X7B_INSTRUCT),
         _FireworksLlm(
@@ -361,7 +347,6 @@ def _text_models():
         _OctoLlm("mixtral-8x7b-instruct", MIXTRAL_8X7B_INSTRUCT),
         _TogetherLlm("mistralai/Mixtral-8x7B-Instruct-v0.1", MIXTRAL_8X7B_INSTRUCT),
         # Llama 3 70b
-        _AnyscaleLlm("meta-llama/Llama-3-70b-chat-hf", LLAMA_3_70B_CHAT),
         _DatabricksLlm("databricks-meta-llama-3-70b-instruct", LLAMA_3_70B_CHAT),
         _DeepInfraLlm("meta-llama/Meta-Llama-3-70B-Instruct", LLAMA_3_70B_CHAT),
         _FireworksLlm(
@@ -386,7 +371,6 @@ def _text_models():
             LLAMA_3_70B_CHAT + "-lora-1b68",
         ),
         # Llama 3 8b
-        _AnyscaleLlm("meta-llama/Llama-3-8b-chat-hf", LLAMA_3_8B_CHAT),
         _CloudflareLlm("@cf/meta/llama-3-8b-instruct", LLAMA_3_8B_CHAT),
         _DeepInfraLlm("meta-llama/Meta-Llama-3-8B-Instruct", LLAMA_3_8B_CHAT),
         _FireworksLlm(

--- a/llm_benchmark_suite.py
+++ b/llm_benchmark_suite.py
@@ -180,7 +180,7 @@ class _GroqLlm(_Llm):
 
 
 class _NvidiaLlm(_Llm):
-    """See https://github.com/NVIDIA/NeMo/tree/main/examples/nlp/text_generation"""
+    """See https://build.nvidia.com/explore/discover"""
 
     def __init__(self, model: str, display_model: Optional[str] = None):
         super().__init__(


### PR DESCRIPTION
Per this announcement:
> We have decided that - going forward - we will be offering the Anyscale Endpoints API exclusively through our fully Hosted Anyscale Platform. Access to Anyscale Endpoints via the multi tenant API will be deprecated as of August 1, 2024.