### PR TITLE
Tweak audio prompt

### DIFF
--- a/llm_benchmark_suite.py
+++ b/llm_benchmark_suite.py
@@ -536,7 +536,7 @@ def _get_prompt(mode: str) -> List[str]:
         ]
     elif mode == "audio":
         return [
-            "Listen to the following audio and provide a response:",
+            "Listen and respond to the following:",
             "--file",
             "media/audio/boolq.wav",
         ]


### PR DESCRIPTION
ultravox-v0.3 was saying that no audio file was provided. Given the closer text-audio alignment, it makes sense for the prompt to be similar to a text prompt.