### PR TITLE
Change cerebras from llama3.1-70b to llama-3.3-70b

### DIFF
--- a/llm_benchmark_suite.py
+++ b/llm_benchmark_suite.py
@@ -369,7 +369,7 @@ def _text_models():
         ),
         # _OvhLlm("llama-3-1-405b-instruct", LLAMA_31_405B_CHAT),
         # Llama 3.1 70b
-        _CerebrasLlm("llama3.1-70b", LLAMA_31_70B_CHAT),
+        _CerebrasLlm("llama-3.3-70b", LLAMA_31_70B_CHAT),
         _CloudflareLlm("@cf/meta/llama-3.1-70b-preview", LLAMA_31_70B_CHAT),
         # _DatabricksLlm("databricks-meta-llama-3.1-70b-instruct", LLAMA_31_70B_CHAT),
         _DeepInfraLlm("meta-llama/Meta-Llama-3.1-70B-Instruct", LLAMA_31_70B_CHAT),


### PR DESCRIPTION
Llama 3.1 70B and 3.3 70B have identical performance, but the later has more fine-tuned weights. Cerebras has transitioned over to only hosting the latter.

I see there is another PR (https://github.com/fixie-ai/ai-benchmarks/pull/132) is adding a llama 3.3 model under the llama 3.1 label. Is there anything special about the display name, or should we add a new set of models `LLAMA_33_70B_CHAT` etal?